### PR TITLE
Enable text grid fields and full-screen preview

### DIFF
--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -73,7 +73,7 @@
                 <button class="btn btn-sm btn-outline-secondary" @onclick="SortOptions">Sort A-Z</button>
             </div>
         }
-        else if (Field.FieldType.StartsWith("grid"))
+        else if (Field.FieldType is "grid_radio" or "grid_checkbox")
         {
             <div class="row mt-3">
                 <div class="col-md-6">
@@ -115,6 +115,29 @@
                         <button class="btn btn-sm btn-outline-primary" @onclick="AddColumn">+ Add Column</button>
                         <button class="btn btn-sm btn-outline-secondary" @onclick="SortColumns">Sort A-Z</button>
                     </div>
+                </div>
+            </div>
+        }
+        else if (Field.FieldType == "grid_text")
+        {
+            <div class="mt-3">
+                <label class="form-label">Grid Columns</label>
+                <div>
+                    @foreach (var (col, idx) in Field.GridColumns.Select((c, i) => (c, i)))
+                    {
+                        <div class="d-flex align-items-center mb-1">
+                            <input class="form-control flex-grow-1" @bind="Field.GridColumns[idx]" />
+                            <div class="btn-group btn-group-sm ms-1">
+                                <button class="btn btn-outline-secondary" @onclick="() => MoveColumnUp(idx)"><span class="material-icons">arrow_upward</span></button>
+                                <button class="btn btn-outline-secondary" @onclick="() => MoveColumnDown(idx)"><span class="material-icons">arrow_downward</span></button>
+                            </div>
+                            <button class="btn btn-outline-danger btn-sm ms-1" @onclick="() => Field.GridColumns.RemoveAt(idx)">×</button>
+                        </div>
+                    }
+                </div>
+                <div class="mt-1 d-flex gap-2">
+                    <button class="btn btn-sm btn-outline-primary" @onclick="AddColumn">+ Add Column</button>
+                    <button class="btn btn-sm btn-outline-secondary" @onclick="SortColumns">Sort A-Z</button>
                 </div>
             </div>
         }

--- a/Client/Components/FieldEditor.razor
+++ b/Client/Components/FieldEditor.razor
@@ -91,7 +91,8 @@
                             </div>
                         }
                     </div>
-                    <div class="mt-1">
+                    <div class="mt-1 d-flex gap-2">
+                        <button class="btn btn-sm btn-outline-primary" @onclick="AddRow">+ Add Row</button>
                         <button class="btn btn-sm btn-outline-secondary" @onclick="SortRows">Sort A-Z</button>
                     </div>
                 </div>
@@ -110,7 +111,8 @@
                             </div>
                         }
                     </div>
-                    <div class="mt-1">
+                    <div class="mt-1 d-flex gap-2">
+                        <button class="btn btn-sm btn-outline-primary" @onclick="AddColumn">+ Add Column</button>
                         <button class="btn btn-sm btn-outline-secondary" @onclick="SortColumns">Sort A-Z</button>
                     </div>
                 </div>
@@ -188,6 +190,7 @@
         "scale" => "Linear Scale",
         "grid_radio" => "Choice Grid",
         "grid_checkbox" => "Checkbox Grid",
+        "grid_text" => "Text Grid",
         "title" => "Title",
         "section" => "Section",
         "file" => "Upload File",
@@ -266,6 +269,18 @@
     void SortColumns()
     {
         Field.GridColumns = Field.GridColumns.OrderBy(o => o, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    async Task AddRow()
+    {
+        Field.GridRows.Add(string.Empty);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    async Task AddColumn()
+    {
+        Field.GridColumns.Add(string.Empty);
+        await InvokeAsync(StateHasChanged);
     }
 
     async Task AddOption()

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -92,6 +92,7 @@
                             break;
                         case "grid_radio":
                         case "grid_checkbox":
+                        case "grid_text":
                             <table class="table table-bordered table-sm">
                                 <thead>
                                     <tr>
@@ -114,9 +115,13 @@
                                                     {
                                                         <input type="radio" name="@($"grid-{field.Key}-{gridRow}")" />
                                                     }
-                                                    else
+                                                    else if (field.FieldType == "grid_checkbox")
                                                     {
                                                         <input type="checkbox" />
+                                                    }
+                                                    else
+                                                    {
+                                                        <input type="text" class="form-control" />
                                                     }
                                                 </td>
                                             }

--- a/Client/Components/LivePreview.razor
+++ b/Client/Components/LivePreview.razor
@@ -92,7 +92,6 @@
                             break;
                         case "grid_radio":
                         case "grid_checkbox":
-                        case "grid_text":
                             <table class="table table-bordered table-sm">
                                 <thead>
                                     <tr>
@@ -115,18 +114,34 @@
                                                     {
                                                         <input type="radio" name="@($"grid-{field.Key}-{gridRow}")" />
                                                     }
-                                                    else if (field.FieldType == "grid_checkbox")
-                                                    {
-                                                        <input type="checkbox" />
-                                                    }
                                                     else
                                                     {
-                                                        <input type="text" class="form-control" />
+                                                        <input type="checkbox" />
                                                     }
                                                 </td>
                                             }
                                         </tr>
                                     }
+                                </tbody>
+                            </table>
+                            break;
+                        case "grid_text":
+                            <table class="table table-bordered table-sm">
+                                <thead>
+                                    <tr>
+                                        @foreach (var col in field.GridColumns)
+                                        {
+                                            <th>@col</th>
+                                        }
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        @foreach (var col in field.GridColumns)
+                                        {
+                                            <td><input type="text" class="form-control" /></td>
+                                        }
+                                    </tr>
                                 </tbody>
                             </table>
                             break;

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -605,11 +605,31 @@ List<object> BuildFieldPayload()
                 var opts = f.OptionItems.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                 var rowsList = f.GridRows.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                 var colsList = f.GridColumns.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
-                string? optionsJson = opts.Count > 0 ? JsonSerializer.Serialize(opts)
-                    : rowsList.Count > 0 || colsList.Count > 0 ? JsonSerializer.Serialize(new { Rows = rowsList, Columns = colsList })
-                    : f.FieldType == "scale" ? JsonSerializer.Serialize(new { Min = f.ScaleMin, Max = f.ScaleMax })
-                    : !string.IsNullOrWhiteSpace(f.Instructions) ? JsonSerializer.Serialize(new { Instructions = f.Instructions })
-                    : null;
+                string? optionsJson;
+                if (opts.Count > 0)
+                {
+                    optionsJson = JsonSerializer.Serialize(opts);
+                }
+                else if (f.FieldType == "grid_text")
+                {
+                    optionsJson = colsList.Count > 0 ? JsonSerializer.Serialize(new { Columns = colsList }) : null;
+                }
+                else if (f.FieldType == "grid_radio" || f.FieldType == "grid_checkbox")
+                {
+                    optionsJson = (rowsList.Count > 0 && colsList.Count > 0) ? JsonSerializer.Serialize(new { Rows = rowsList, Columns = colsList }) : null;
+                }
+                else if (f.FieldType == "scale")
+                {
+                    optionsJson = JsonSerializer.Serialize(new { Min = f.ScaleMin, Max = f.ScaleMax });
+                }
+                else if (!string.IsNullOrWhiteSpace(f.Instructions))
+                {
+                    optionsJson = JsonSerializer.Serialize(new { Instructions = f.Instructions });
+                }
+                else
+                {
+                    optionsJson = null;
+                }
                 list.Add(new
                 {
                     f.Key,
@@ -759,7 +779,7 @@ List<object> BuildFieldPayload()
                 return;
             }
 
-            if ((f.FieldType == "grid_radio" || f.FieldType == "grid_checkbox" || f.FieldType == "grid_text") &&
+            if ((f.FieldType == "grid_radio" || f.FieldType == "grid_checkbox") &&
                 (!f.GridRows.Any(r => !string.IsNullOrWhiteSpace(r)) || !f.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c))))
             {
                 NotificationService.Notify(new NotificationMessage
@@ -767,6 +787,16 @@ List<object> BuildFieldPayload()
                     Severity = NotificationSeverity.Warning,
                     Summary = "Options Required",
                     Detail = $"Add at least one row and column for '{f.Label}'."
+                });
+                return;
+            }
+            if (f.FieldType == "grid_text" && !f.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c)))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Options Required",
+                    Detail = $"Add at least one column for '{f.Label}'."
                 });
                 return;
             }

--- a/Client/Pages/DynamicForms/EditFormPage.razor
+++ b/Client/Pages/DynamicForms/EditFormPage.razor
@@ -60,6 +60,7 @@ else if (!string.IsNullOrEmpty(deletedMessage))
                 <div class="draggable-field" draggable="true" data-type="scale"><span class="material-icons me-1">linear_scale</span> Linear Scale</div>
                 <div class="draggable-field" draggable="true" data-type="grid_radio"><span class="material-icons me-1">grid_on</span> Choice Grid</div>
                 <div class="draggable-field" draggable="true" data-type="grid_checkbox"><span class="material-icons me-1">grid_view</span> Checkbox Grid</div>
+                <div class="draggable-field" draggable="true" data-type="grid_text"><span class="material-icons me-1">border_all</span> Text Grid</div>
                 <div class="draggable-field" draggable="true" data-type="file"><span class="material-icons me-1">upload_file</span> Upload File</div>
                 <div class="draggable-field" draggable="true" data-type="image"><span class="material-icons me-1">image</span> Image</div>
                 <div class="draggable-field" draggable="true" data-type="statictext"><span class="material-icons me-1">text_fields</span> Text</div>
@@ -186,17 +187,8 @@ else if (!string.IsNullOrEmpty(deletedMessage))
 }
 else
 {
-    <div class="row">
-        <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
-            <div class="mb-3">
-                <h5 class="mb-0">Toolbox</h5>
-            </div>
-        </div>
-        <div class="col-md-9">
-            <div class="card p-3 shadow-sm">
-                <LivePreview Sections="sections" FormName="@formName" />
-            </div>
-        </div>
+    <div class="card p-3 shadow-sm">
+        <LivePreview Sections="sections" FormName="@formName" />
     </div>
 }
 
@@ -767,7 +759,7 @@ List<object> BuildFieldPayload()
                 return;
             }
 
-            if ((f.FieldType == "grid_radio" || f.FieldType == "grid_checkbox") &&
+            if ((f.FieldType == "grid_radio" || f.FieldType == "grid_checkbox" || f.FieldType == "grid_text") &&
                 (!f.GridRows.Any(r => !string.IsNullOrWhiteSpace(r)) || !f.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c))))
             {
                 NotificationService.Notify(new NotificationMessage

--- a/Client/Pages/DynamicForms/FormDesigner.razor
+++ b/Client/Pages/DynamicForms/FormDesigner.razor
@@ -81,6 +81,7 @@
                         <option value="scale">Linear Scale</option>
                         <option value="grid_radio">Multiple Choice Grid</option>
                         <option value="grid_checkbox">Checkbox Grid</option>
+                        <option value="grid_text">Text Grid</option>
                         <option value="title">Title and Description</option>
                         <option value="section">Section</option>
                         <option value="file">Upload File</option>

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -376,7 +376,7 @@ else
                     "checkbox" => new List<string>(),
                     "grid_radio" => new Dictionary<string, string>(),
                     "grid_checkbox" => new Dictionary<string, List<string>>(),
-                    "grid_text" => new List<Dictionary<string, string>> { new Dictionary<string, string>() },
+                    "grid_text" => new List<Dictionary<string, string>>(),
                     "number" => (object?)null,
                     "date" => (object?)null,
                     "time" => (object?)null,
@@ -550,7 +550,7 @@ else
     {
         if (responseData[key] is List<Dictionary<string, string>> list)
             return list;
-        var newList = new List<Dictionary<string, string>> { new Dictionary<string, string>() };
+        var newList = new List<Dictionary<string, string>>();
         responseData[key] = newList;
         return newList;
     }

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -160,7 +160,6 @@ else
 
                     case "grid_radio":
                     case "grid_checkbox":
-                    case "grid_text":
                         var gridOpts = JsonSerializer.Deserialize<GridOptions>(fld.OptionsJson ?? "{}") ?? new();
                         <table class="table table-bordered table-sm">
                             <thead>
@@ -187,17 +186,11 @@ else
                                                            checked="@GetGridRadioChecked(fld.Key, row, col)"
                                                            @onchange="() => OnGridRadioChanged(fld.Key, row, col)" />
                                                 }
-                                                else if (fld.FieldType == "grid_checkbox")
+                                                else
                                                 {
                                                     <input type="checkbox"
                                                            checked="@GetGridCheckboxChecked(fld.Key, row, col)"
                                                            @onchange="e => OnGridCheckboxChanged(fld.Key, row, col, e)" />
-                                                }
-                                                else
-                                                {
-                                                    <input type="text" class="form-control"
-                                                           value="@GetGridTextValue(fld.Key, row, col)"
-                                                           @onchange="e => OnGridTextChanged(fld.Key, row, col, e)" />
                                                 }
                                             </td>
                                         }
@@ -205,6 +198,40 @@ else
                                 }
                             </tbody>
                         </table>
+                        break;
+                    case "grid_text":
+                        var textGrid = JsonSerializer.Deserialize<GridOptions>(fld.OptionsJson ?? "{}") ?? new();
+                        var rows = GetTextGridRows(fld.Key);
+                        <table class="table table-bordered table-sm">
+                            <thead>
+                                <tr>
+                                    @foreach (var col in textGrid.Columns)
+                                    {
+                                        <th>@col</th>
+                                    }
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @for (int i = 0; i < rows.Count; i++)
+                                {
+                                    <tr>
+                                        @foreach (var col in textGrid.Columns)
+                                        {
+                                            <td>
+                                                <input type="text" class="form-control"
+                                                       value="@GetTextGridValue(fld.Key, i, col)"
+                                                       @onchange="e => OnTextGridChanged(fld.Key, i, col, e)" />
+                                            </td>
+                                        }
+                                        <td>
+                                            <button type="button" class="btn btn-sm btn-outline-danger" @onclick="() => RemoveTextGridRow(fld.Key, i)">×</button>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                        <button type="button" class="btn btn-sm btn-outline-primary" @onclick="() => AddTextGridRow(fld.Key)">+ Add Row</button>
                         break;
 
                     case "file":
@@ -349,7 +376,7 @@ else
                     "checkbox" => new List<string>(),
                     "grid_radio" => new Dictionary<string, string>(),
                     "grid_checkbox" => new Dictionary<string, List<string>>(),
-                    "grid_text" => new Dictionary<string, Dictionary<string, string>>(),
+                    "grid_text" => new List<Dictionary<string, string>> { new Dictionary<string, string>() },
                     "number" => (object?)null,
                     "date" => (object?)null,
                     "time" => (object?)null,
@@ -492,13 +519,6 @@ else
         obj is Dictionary<string, List<string>> map &&
         map.TryGetValue(row, out var list) && list.Contains(column);
 
-    string GetGridTextValue(string key, string row, string column) =>
-        responseData.TryGetValue(key, out var obj) &&
-        obj is Dictionary<string, Dictionary<string, string>> map &&
-        map.TryGetValue(row, out var rowMap) && rowMap.TryGetValue(column, out var val)
-            ? val
-            : string.Empty;
-
     void OnGridRadioChanged(string key, string row, string column)
     {
         if (responseData[key] is not Dictionary<string, string> map)
@@ -526,16 +546,39 @@ else
         }
     }
 
-    void OnGridTextChanged(string key, string row, string column, ChangeEventArgs e)
+    List<Dictionary<string, string>> GetTextGridRows(string key)
     {
-        if (responseData[key] is not Dictionary<string, Dictionary<string, string>> map)
-            responseData[key] = map = new();
-        if (!map.TryGetValue(row, out var rowMap))
-        {
-            rowMap = new();
-            map[row] = rowMap;
-        }
-        rowMap[column] = e.Value?.ToString() ?? string.Empty;
+        if (responseData[key] is List<Dictionary<string, string>> list)
+            return list;
+        var newList = new List<Dictionary<string, string>> { new Dictionary<string, string>() };
+        responseData[key] = newList;
+        return newList;
+    }
+
+    string GetTextGridValue(string key, int rowIndex, string column)
+    {
+        var rows = GetTextGridRows(key);
+        return rowIndex < rows.Count && rows[rowIndex].TryGetValue(column, out var val) ? val : string.Empty;
+    }
+
+    void OnTextGridChanged(string key, int rowIndex, string column, ChangeEventArgs e)
+    {
+        var rows = GetTextGridRows(key);
+        while (rows.Count <= rowIndex)
+            rows.Add(new Dictionary<string, string>());
+        rows[rowIndex][column] = e.Value?.ToString() ?? string.Empty;
+    }
+
+    void AddTextGridRow(string key)
+    {
+        GetTextGridRows(key).Add(new Dictionary<string, string>());
+    }
+
+    void RemoveTextGridRow(string key, int index)
+    {
+        var rows = GetTextGridRows(key);
+        if (index >= 0 && index < rows.Count)
+            rows.RemoveAt(index);
     }
 
     private async Task OnFileUploadChanged(string key, InputFileChangeEventArgs e)

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -158,6 +158,55 @@ else
                         }
                         break;
 
+                    case "grid_radio":
+                    case "grid_checkbox":
+                    case "grid_text":
+                        var gridOpts = JsonSerializer.Deserialize<GridOptions>(fld.OptionsJson ?? "{}") ?? new();
+                        <table class="table table-bordered table-sm">
+                            <thead>
+                                <tr>
+                                    <th></th>
+                                    @foreach (var col in gridOpts.Columns)
+                                    {
+                                        <th>@col</th>
+                                    }
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var row in gridOpts.Rows)
+                                {
+                                    <tr>
+                                        <td><strong>@row</strong></td>
+                                        @foreach (var col in gridOpts.Columns)
+                                        {
+                                            <td>
+                                                @if (fld.FieldType == "grid_radio")
+                                                {
+                                                    <input type="radio"
+                                                           name="@($"{fld.Key}-{row}")"
+                                                           checked="@GetGridRadioChecked(fld.Key, row, col)"
+                                                           @onchange="() => OnGridRadioChanged(fld.Key, row, col)" />
+                                                }
+                                                else if (fld.FieldType == "grid_checkbox")
+                                                {
+                                                    <input type="checkbox"
+                                                           checked="@GetGridCheckboxChecked(fld.Key, row, col)"
+                                                           @onchange="e => OnGridCheckboxChanged(fld.Key, row, col, e)" />
+                                                }
+                                                else
+                                                {
+                                                    <input type="text" class="form-control"
+                                                           value="@GetGridTextValue(fld.Key, row, col)"
+                                                           @onchange="e => OnGridTextChanged(fld.Key, row, col, e)" />
+                                                }
+                                            </td>
+                                        }
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                        break;
+
                     case "file":
                         <InputFile OnChange="e => OnFileUploadChanged(fld.Key, e)" />
                         @if (responseData.ContainsKey(fld.Key))
@@ -298,6 +347,9 @@ else
                 responseData[fld.Key] = fld.FieldType switch
                 {
                     "checkbox" => new List<string>(),
+                    "grid_radio" => new Dictionary<string, string>(),
+                    "grid_checkbox" => new Dictionary<string, List<string>>(),
+                    "grid_text" => new Dictionary<string, Dictionary<string, string>>(),
                     "number" => (object?)null,
                     "date" => (object?)null,
                     "time" => (object?)null,
@@ -430,6 +482,62 @@ else
         }
     }
 
+    bool GetGridRadioChecked(string key, string row, string column) =>
+        responseData.TryGetValue(key, out var obj) &&
+        obj is Dictionary<string, string> map &&
+        map.TryGetValue(row, out var val) && val == column;
+
+    bool GetGridCheckboxChecked(string key, string row, string column) =>
+        responseData.TryGetValue(key, out var obj) &&
+        obj is Dictionary<string, List<string>> map &&
+        map.TryGetValue(row, out var list) && list.Contains(column);
+
+    string GetGridTextValue(string key, string row, string column) =>
+        responseData.TryGetValue(key, out var obj) &&
+        obj is Dictionary<string, Dictionary<string, string>> map &&
+        map.TryGetValue(row, out var rowMap) && rowMap.TryGetValue(column, out var val)
+            ? val
+            : string.Empty;
+
+    void OnGridRadioChanged(string key, string row, string column)
+    {
+        if (responseData[key] is not Dictionary<string, string> map)
+            responseData[key] = map = new();
+        map[row] = column;
+    }
+
+    void OnGridCheckboxChanged(string key, string row, string column, ChangeEventArgs e)
+    {
+        if (responseData[key] is not Dictionary<string, List<string>> map)
+            responseData[key] = map = new();
+        if (!map.TryGetValue(row, out var list))
+        {
+            list = new();
+            map[row] = list;
+        }
+        if ((bool?)e.Value == true)
+        {
+            if (!list.Contains(column))
+                list.Add(column);
+        }
+        else
+        {
+            list.Remove(column);
+        }
+    }
+
+    void OnGridTextChanged(string key, string row, string column, ChangeEventArgs e)
+    {
+        if (responseData[key] is not Dictionary<string, Dictionary<string, string>> map)
+            responseData[key] = map = new();
+        if (!map.TryGetValue(row, out var rowMap))
+        {
+            rowMap = new();
+            map[row] = rowMap;
+        }
+        rowMap[column] = e.Value?.ToString() ?? string.Empty;
+    }
+
     private async Task OnFileUploadChanged(string key, InputFileChangeEventArgs e)
     {
         var file = e.File;
@@ -536,7 +644,16 @@ else
         if (value == null) return true;
         if (value is string s) return string.IsNullOrWhiteSpace(s);
         if (value is IEnumerable<string> list) return !list.Any();
+        if (value is Dictionary<string, string> d1) return d1.Count == 0 || d1.Values.All(string.IsNullOrWhiteSpace);
+        if (value is Dictionary<string, List<string>> d2) return d2.Count == 0 || d2.Values.All(v => v.Count == 0);
+        if (value is Dictionary<string, Dictionary<string, string>> d3) return d3.Count == 0 || d3.Values.All(v => v.Values.All(string.IsNullOrWhiteSpace));
         return false;
+    }
+
+    class GridOptions
+    {
+        public List<string> Rows { get; set; } = new();
+        public List<string> Columns { get; set; } = new();
     }
 
     private class FileUploadResult

--- a/Client/Pages/DynamicForms/FormRenderer.razor
+++ b/Client/Pages/DynamicForms/FormRenderer.razor
@@ -549,8 +549,12 @@ else
     List<Dictionary<string, string>> GetTextGridRows(string key)
     {
         if (responseData[key] is List<Dictionary<string, string>> list)
+        {
+            if (list.Count == 0)
+                list.Add(new Dictionary<string, string>());
             return list;
-        var newList = new List<Dictionary<string, string>>();
+        }
+        var newList = new List<Dictionary<string, string>> { new Dictionary<string, string>() };
         responseData[key] = newList;
         return newList;
     }
@@ -564,8 +568,8 @@ else
     void OnTextGridChanged(string key, int rowIndex, string column, ChangeEventArgs e)
     {
         var rows = GetTextGridRows(key);
-        while (rows.Count <= rowIndex)
-            rows.Add(new Dictionary<string, string>());
+        if (rowIndex < 0 || rowIndex >= rows.Count)
+            return;
         rows[rowIndex][column] = e.Value?.ToString() ?? string.Empty;
     }
 

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -53,6 +53,7 @@
                 <div class="draggable-field" draggable="true" data-type="scale"><span class="material-icons me-1">linear_scale</span> Linear Scale</div>
                 <div class="draggable-field" draggable="true" data-type="grid_radio"><span class="material-icons me-1">grid_on</span> Choice Grid</div>
                 <div class="draggable-field" draggable="true" data-type="grid_checkbox"><span class="material-icons me-1">grid_view</span> Checkbox Grid</div>
+                <div class="draggable-field" draggable="true" data-type="grid_text"><span class="material-icons me-1">border_all</span> Text Grid</div>
                 <div class="draggable-field" draggable="true" data-type="file"><span class="material-icons me-1">upload_file</span> Upload File</div>
                 <div class="draggable-field" draggable="true" data-type="image"><span class="material-icons me-1">image</span> Image</div>
                 <div class="draggable-field" draggable="true" data-type="statictext"><span class="material-icons me-1">text_fields</span> Text</div>
@@ -170,17 +171,8 @@
 }
 else
 {
-    <div class="row">
-        <div class="col-md-3" style="position:sticky;top:75px;max-height:calc(100vh - 90px);overflow-y:auto;">
-            <div class="mb-3">
-                <h5 class="mb-0">Toolbox</h5>
-            </div>
-        </div>
-        <div class="col-md-9">
-            <div class="card p-3 shadow-sm">
-                <LivePreview Sections="sections" FormName="@formName" />
-            </div>
-        </div>
+    <div class="card p-3 shadow-sm">
+        <LivePreview Sections="sections" FormName="@formName" />
     </div>
 }
 
@@ -627,7 +619,7 @@ else
                 return;
             }
 
-            if ((f.FieldType == "grid_radio" || f.FieldType == "grid_checkbox") &&
+            if ((f.FieldType == "grid_radio" || f.FieldType == "grid_checkbox" || f.FieldType == "grid_text") &&
                 (!f.GridRows.Any(r => !string.IsNullOrWhiteSpace(r)) || !f.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c))))
             {
                 NotificationService.Notify(new NotificationMessage

--- a/Client/Pages/DynamicForms/Index.razor
+++ b/Client/Pages/DynamicForms/Index.razor
@@ -550,11 +550,31 @@ else
                     var opts = f.OptionItems.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                     var rowsList = f.GridRows.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
                     var colsList = f.GridColumns.Where(o => !string.IsNullOrWhiteSpace(o)).ToList();
-                    string? optionsJson = opts.Count > 0 ? JsonSerializer.Serialize(opts)
-                        : rowsList.Count > 0 || colsList.Count > 0 ? JsonSerializer.Serialize(new { Rows = rowsList, Columns = colsList })
-                        : f.FieldType == "scale" ? JsonSerializer.Serialize(new { Min = f.ScaleMin, Max = f.ScaleMax })
-                        : !string.IsNullOrWhiteSpace(f.Instructions) ? JsonSerializer.Serialize(new { Instructions = f.Instructions })
-                        : null;
+                    string? optionsJson;
+                    if (opts.Count > 0)
+                    {
+                        optionsJson = JsonSerializer.Serialize(opts);
+                    }
+                    else if (f.FieldType == "grid_text")
+                    {
+                        optionsJson = colsList.Count > 0 ? JsonSerializer.Serialize(new { Columns = colsList }) : null;
+                    }
+                    else if (f.FieldType == "grid_radio" || f.FieldType == "grid_checkbox")
+                    {
+                        optionsJson = (rowsList.Count > 0 && colsList.Count > 0) ? JsonSerializer.Serialize(new { Rows = rowsList, Columns = colsList }) : null;
+                    }
+                    else if (f.FieldType == "scale")
+                    {
+                        optionsJson = JsonSerializer.Serialize(new { Min = f.ScaleMin, Max = f.ScaleMax });
+                    }
+                    else if (!string.IsNullOrWhiteSpace(f.Instructions))
+                    {
+                        optionsJson = JsonSerializer.Serialize(new { Instructions = f.Instructions });
+                    }
+                    else
+                    {
+                        optionsJson = null;
+                    }
                     list.Add(new
                     {
                         f.Key,
@@ -619,7 +639,7 @@ else
                 return;
             }
 
-            if ((f.FieldType == "grid_radio" || f.FieldType == "grid_checkbox" || f.FieldType == "grid_text") &&
+            if ((f.FieldType == "grid_radio" || f.FieldType == "grid_checkbox") &&
                 (!f.GridRows.Any(r => !string.IsNullOrWhiteSpace(r)) || !f.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c))))
             {
                 NotificationService.Notify(new NotificationMessage
@@ -627,6 +647,16 @@ else
                     Severity = NotificationSeverity.Warning,
                     Summary = "Options Required",
                     Detail = $"Add at least one row and column for '{f.Label}'."
+                });
+                return;
+            }
+            if (f.FieldType == "grid_text" && !f.GridColumns.Any(c => !string.IsNullOrWhiteSpace(c)))
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Options Required",
+                    Detail = $"Add at least one column for '{f.Label}'."
                 });
                 return;
             }

--- a/Server/Services/DynamicFormService.cs
+++ b/Server/Services/DynamicFormService.cs
@@ -721,6 +721,7 @@ namespace DynamicFormsApp.Server.Services
             "textarea" => "NVARCHAR(MAX)",
             "grid_radio" => "NVARCHAR(MAX)",    // JSON object
             "grid_checkbox" => "NVARCHAR(MAX)", // JSON object
+            "grid_text" => "NVARCHAR(MAX)",     // JSON object
             "scale" => "INT",
             _ => "NVARCHAR(MAX)"
         };


### PR DESCRIPTION
## Summary
- show new-form preview in full-screen view
- allow adding rows and columns to grid fields and support text grid questions
- render grid responses properly and handle new text grid on server

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a75c9e222c8329920fcc90e60d59a7